### PR TITLE
Fix sakoe-chiba band implementation

### DIFF
--- a/src/algorithms/utils.rs
+++ b/src/algorithms/utils.rs
@@ -90,6 +90,7 @@ impl<T> Matrix<T> {
         }
     }
 
+    #[allow(dead_code)]
     pub fn from_iter(iter: impl Iterator<Item = T>, i: usize, j: usize) -> Self {
         Self {
             data: Box::from_iter(iter),

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -34,8 +34,8 @@ fn dynamic_time_warping_with_distance_closure() {
 
     let dtw = DynamicTimeWarping::with_closure(&a, &b, |a, b| f64::abs(a - b));
 
-    assert_eq!(dtw.distance(),expected_distance);
-    assert_eq!(*dtw.path(),expected_path);
+    assert_eq!(dtw.distance(), expected_distance);
+    assert_eq!(*dtw.path(), expected_path);
 }
 
 #[test]
@@ -44,6 +44,19 @@ fn dynamic_time_warping_with_band_restriction() {
     let b = [2.0, 0.0, 0.0, 8.0, 7.0, 2.0];
     let expected_path = [(0, 0), (0, 1), (1, 2), (2, 3), (3, 4), (4, 5)];
     let expected_distance = 12.0;
+
+    let dtw = DynamicTimeWarping::with_param(&a, &b, Restriction::Band(1));
+
+    assert_eq!(dtw.distance(), expected_distance);
+    assert_eq!(*dtw.path(), expected_path);
+}
+#[test]
+fn dynamic_time_warping_with_corner_out_of_band() {
+    let a = [1.0, 3.0, 9.0, 2.0];
+    let b = [2.0, 0.0];
+    // The path should actually be cut off at (2, 1)
+    let expected_path = [(0, 0), (1, 0), (2, 1), (3, 1)];
+    let expected_distance = 11.0;
 
     let dtw = DynamicTimeWarping::with_param(&a, &b, Restriction::Band(1));
 


### PR DESCRIPTION
adjust Restriction::Iter, Restriction::Range and DynamicTimeWarping::distance to work with the band restriction.

Add some test for band edge cases.

The `expected_matrix` in `compute_matrix_restricted_band_with_example` was changed (slightly) according to my understanding of how the band should be applied.